### PR TITLE
Release 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphatango/openapi",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Wrapper around openapi-factory",
   "main": "lib/index.js",
   "private": false,
@@ -31,10 +31,10 @@
     "openapi-factory": "4.4.226"
   },
   "peerDependencies": {
-    "@alphatango/exceptions": "~2.0.0"
+    "@alphatango/exceptions": "^2.0.0"
   },
   "devDependencies": {
-    "@alphatango/exceptions": "~2.0.0",
+    "@alphatango/exceptions": "^2.1.0",
     "@types/jest": "26.0.8",
     "@types/uuid": "8.3.0",
     "eslint": "7.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@alphatango/exceptions@~2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@alphatango/exceptions/-/exceptions-2.0.0.tgz#320e46798f824dffedda716915c965833152d92a"
-  integrity sha512-UM5b7uYqlp1QBJByviubujEfjeN54/d3FBrOTIy/d/AVyC+iSG+xGT7C24dVzQhSAgNgo0Cn5rjXvR6rDDRYqg==
+"@alphatango/exceptions@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@alphatango/exceptions/-/exceptions-2.1.0.tgz#262a538d866992863c830b26c93e7223f4fe4c9c"
+  integrity sha512-voYw0yrS7dLwnvFYyT36O64VozuE7CK3vrsaPTvOoCOVVLnblSTunir7oawht3+xaWESk+X3syT7YC+3eKMoGw==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"


### PR DESCRIPTION
- unlock exceptions peerDep to only depend on the major version